### PR TITLE
Fix Frida step by removing Listen option from all

### DIFF
--- a/android_unpinner/__main__.py
+++ b/android_unpinner/__main__.py
@@ -247,7 +247,6 @@ listen_option = click.option(
 @cli.command("all")
 @verbosity_option
 @force_option
-@listen_option
 @click.argument(
     "apk-files",
     type=click.Path(path_type=Path, exists=True),

--- a/android_unpinner/__main__.py
+++ b/android_unpinner/__main__.py
@@ -231,7 +231,8 @@ force_option = click.option(
 
 def _listen(ctx, param, val):
     global gadget_config_file
-    gadget_config_file = gadget_config_file_listen
+    if val:
+        gadget_config_file = gadget_config_file_listen
 
 
 listen_option = click.option(
@@ -247,6 +248,7 @@ listen_option = click.option(
 @cli.command("all")
 @verbosity_option
 @force_option
+@listen_option
 @click.argument(
     "apk-files",
     type=click.Path(path_type=Path, exists=True),


### PR DESCRIPTION
As the title states, android-unpinner seemingly got stuck at the step "Inject Frida gadget". Logcat did not reveal any Frida execution, apart from it starting a server. After having manually read the entire repo's code, it became obvious that the culprit was Frida's listen mode. 

Added in PR #19 , this feature is used in order to send Frida scripts via a connection, rather than executing the local scripts. This is in contrast to the rest of the program, that copies the script files into Android's memory multiple times. 

The fix is simple, as by removing the listen_command decorator from the all command function, everything works as expected. This might have been an oversight by the original PR's contributor, as starting Frida in listen mode is a corner case and 100% not the intended behaviour of the "regular" script's execution.