### PR TITLE
fix: set DEBUG_MODE variable and add Conscrypt bypass

### DIFF
--- a/android_unpinner/scripts/httptoolkit-unpinner.js
+++ b/android_unpinner/scripts/httptoolkit-unpinner.js
@@ -26,6 +26,8 @@
  *
  *************************************************************************************************/
 
+const DEBUG_MODE = false;
+
 function buildX509CertificateFromBytes(certBytes) {
     const ByteArrayInputStream = Java.use('java.io.ByteArrayInputStream');
     const CertFactory = Java.use('java.security.cert.CertificateFactory');
@@ -430,8 +432,26 @@ const PINNING_FIXES = {
                 };
             }
         }
+    ],
+    
+    'com.android.org.conscrypt.TrustManagerImpl': [
+        {
+            methodName: 'checkTrustedRecursive',
+            replacement: () => {
+                const arrayList = Java.use("java.util.ArrayList")
+                return function (
+                    certs,
+                    host,
+                    clientAuth,
+                    untrustedChain,
+                    trustAnchorChain,
+                    used
+                )  {
+                    return arrayList.$new();
+                }
+            }
+        }
     ]
-
 };
 
 const getJavaClassIfExists = (clsName) => {


### PR DESCRIPTION
## Issue

This PR https://github.com/mitmproxy/android-unpinner/pull/38 broke the tools, at least on my setup: DEBUG_MODE is not defined, causing a reference error.

## Replicate the issue

`android-unpinner all -l -f ./apks/xxxxx.apk`
then
`frida -U -l tools/android-unpinner/android_unpinner/scripts/hide-debugger.js -l tools/android-unpinner/android_unpinner/scripts/httptoolkit-unpinner.js MyApp`
gives 
[<img width="880" alt="Screenshot 2024-12-28 at 17 15 22" src="https://github.com/user-attachments/assets/a3e10d4a-76dd-43aa-bcd3-4bea027276cf" />
](url)


## Explanation

Unlike https://github.com/httptoolkit/frida-interception-and-unpinning, we don't have a config file in this project

Defining the variable fixes it and properly allows to apply patches

## Bonus

Also ~~added~~ brought back another common bypass (inspired by objection https://github.com/sensepost/objection/blob/master/agent/src/android/pinning.ts#L244) 
edit: turns out it was also deleted in https://github.com/mitmproxy/android-unpinner/pull/38 , see https://github.com/mitmproxy/android-unpinner/pull/38/files#diff-523754949d164f3759f5cfd8712b416590e6e9cf60810aa1e7ddf19346428793L147

I can make a dedicated PR for the bonus if you prefer