### PR TITLE
Use native mkdir function if not exists

### DIFF
--- a/android_unpinner/__main__.py
+++ b/android_unpinner/__main__.py
@@ -364,7 +364,7 @@ def get_apks(package: str, outdir: Path) -> None:
         raise RuntimeError(f"Unxepected output from pm path: {package_info!r}")
     apks = [p.removeprefix("package:") for p in package_info.splitlines()]
     if not outdir.exists():
-        Path.mkdir(outdir)
+        outdir.mkdir()
     for apk in apks:
         logging.info(f"Getting {apk}...")
         outfile = outdir / Path(apk).name


### PR DESCRIPTION
* `outdir` argument is already part of `Path` class so we can use direct mkdir function from it

This cleanup commit 88759c86e6513cc992bd8d4e522148b3a005708c.

Test:
android-unpinner get-apks tech.httptoolkit.pinning_demo . -> passed
android-unpinner get-apks tech.httptoolkit.pinning_demo test -> passed