### PR TITLE
eat: Add Device Selection Option (-d/--device)

### DIFF
--- a/android_unpinner/vendor/platform_tools/__init__.py
+++ b/android_unpinner/vendor/platform_tools/__init__.py
@@ -29,3 +29,9 @@ def adb(cmd: str) -> subprocess.CompletedProcess[str]:
         raise
     logging.debug(f"cmd='{cmd}'\n" f"{proc.stdout=}\n" f"{proc.stderr=}")
     return proc
+
+
+def set_device(device_serial: str | None) -> None:
+    """Set the target device for all adb commands."""
+    global device
+    device = device_serial

--- a/android_unpinner/vendor/platform_tools/__init__.py
+++ b/android_unpinner/vendor/platform_tools/__init__.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+device: str | None = None
 here = Path(__file__).absolute().parent
 
 if sys.platform == "win32":
@@ -16,14 +17,15 @@ else:
 def adb(cmd: str) -> subprocess.CompletedProcess[str]:
     """Helper function to call adb and capture stdout."""
     cmd = f"{adb_binary} {cmd}"
+    if device:
+        cmd += f" -s {device}"
+        logging.debug(f"Using device: {device}")
     try:
-        proc = subprocess.run(cmd, shell=True, check=True, capture_output=True, text=True)
+        proc = subprocess.run(
+            cmd, shell=True, check=True, capture_output=True, text=True
+        )
     except subprocess.CalledProcessError as e:
-        logging.debug(f"cmd='{cmd}'\n"
-                      f"{e.stdout=}\n"
-                      f"{e.stderr=}")
+        logging.debug(f"cmd='{cmd}'\n" f"{e.stdout=}\n" f"{e.stderr=}")
         raise
-    logging.debug(f"cmd='{cmd}'\n"
-                  f"{proc.stdout=}\n"
-                  f"{proc.stderr=}")
+    logging.debug(f"cmd='{cmd}'\n" f"{proc.stdout=}\n" f"{proc.stderr=}")
     return proc


### PR DESCRIPTION
- Updated logging messages to remove f-string formatting for consistency.
- Introduced a new device option to allow users to specify the target device when multiple devices are connected, enhancing usability across commands.