### PR TITLE
Fix: place -s before adb subcommand and improve logging 

### DIFF
--- a/android_unpinner/vendor/platform_tools/__init__.py
+++ b/android_unpinner/vendor/platform_tools/__init__.py
@@ -23,7 +23,7 @@ def adb(cmd: str) -> subprocess.CompletedProcess[str]:
     full_cmd = f"{base} {cmd}"
     try:
         proc = subprocess.run(
-            full_cmd, shell=True, check=True, capture_output=True, text=True
+            full_cmd, shell=False, check=True, capture_output=True, text=True
         )
     except subprocess.CalledProcessError as e:
         logging.debug(f"cmd='{full_cmd}'\n" f"{e.stdout=}\n" f"{e.stderr=}")


### PR DESCRIPTION
In this PR I have addressed the following issue:
- ADB `-s` was in the wrong order (a bug introduced by me).

it now follows their syntax [adb](https://developer.android.com/tools/adb)

Side notes:
- String based commands can be fragile but as of now everything seems to be working and that's how the project was setup, a migration from strings to list would be beneficial.

- I tested this with windows and worked fine, however testing in other platforms would be good.
- Heres my little "test" script: [gist](https://gist.github.com/Davis-3450/b2c8a6738ec716f29263850fc12ddad5)

Risk: low sope
- Changes are localized to command construction and logging
