### PR TITLE
Fix adb execs for unix-like systems, use list-based adb args

### DIFF
--- a/android_unpinner/vendor/platform_tools/__init__.py
+++ b/android_unpinner/vendor/platform_tools/__init__.py
@@ -14,21 +14,22 @@ else:
     adb_binary = here / "linux" / "adb"
 
 
-def adb(cmd: str) -> subprocess.CompletedProcess[str]:
+def adb(cmd: list[str]) -> subprocess.CompletedProcess[str]:
     """Helper function to call adb and capture stdout."""
-    base = f"{adb_binary}"
+    base = [str(adb_binary)]
     if device:
-        base += f" -s {device}"
+        base += ["-s", device]
         logging.debug(f"Using device: {device}")
-    full_cmd = f"{base} {cmd}"
+    full_cmd = base + cmd
+    full_cmd_str = " ".join(full_cmd)
     try:
         proc = subprocess.run(
-            full_cmd, shell=False, check=True, capture_output=True, text=True
+            full_cmd, check=True, capture_output=True, text=True
         )
     except subprocess.CalledProcessError as e:
-        logging.debug(f"cmd='{full_cmd}'\n" f"{e.stdout=}\n" f"{e.stderr=}")
+        logging.debug(f"cmd='{full_cmd_str}'\n" f"{e.stdout=}\n" f"{e.stderr=}")
         raise
-    logging.debug(f"cmd='{full_cmd}'\n" f"{proc.stdout=}\n" f"{proc.stderr=}")
+    logging.debug(f"cmd='{full_cmd_str}'\n" f"{proc.stdout=}\n" f"{proc.stderr=}")
     return proc
 
 


### PR DESCRIPTION
- Switched to list-based arguments instead of a string-based args to fix adb calls on Unix-like systems. Currently, they fail because they treat the string as a single command with no args. See [here](https://github.com/mitmproxy/android-unpinner/pull/50#issuecomment-3340904702).
- Improved the error message raised when start-app fails to find specified activities.