### PR TITLE
bugfix: rollback shell=True for both windows and linux compatibility

### DIFF
--- a/android_unpinner/vendor/platform_tools/__init__.py
+++ b/android_unpinner/vendor/platform_tools/__init__.py
@@ -23,7 +23,7 @@ def adb(cmd: str) -> subprocess.CompletedProcess[str]:
     full_cmd = f"{base} {cmd}"
     try:
         proc = subprocess.run(
-            full_cmd, shell=False, check=True, capture_output=True, text=True
+            full_cmd, shell=True, check=True, capture_output=True, text=True
         )
     except subprocess.CalledProcessError as e:
         logging.debug(f"cmd='{full_cmd}'\n" f"{e.stdout=}\n" f"{e.stderr=}")


### PR DESCRIPTION
As mentioned in: #50 `shell=False` made the program break on Linux, so it has been rolled back to `True` while this is generally a bad practice, with the current "string based" implementation it was the quicker solution.

Note that #52 also addresses both issues and refactors the commands to use lists, which is the better long-term approach.

That said, it’s safer to merge this PR first since it’s a granular bugfix rather than a full refactor and then move on to #52.