### PR TITLE
Add native support for XAPKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This tool removes certificate pinning from APKs.
  - Includes a custom Java Debug Wire Protocol implementation to inject the Frida Gadget via ADB.
  - Uses [HTTPToolkit's excellent unpinning script](https://github.com/httptoolkit/frida-android-unpinning) to defeat certificate pinning.
  - Already includes all native dependencies for Windows/Linux/macOS (`adb`, `apksigner`, `zipalign`, `aapt2`).
+ - Handles XAPKs by extracting the split APKs, unpinning them and installing them with `adb install-multiple`. 
 
 The goal was not to build yet another unpinning tool, but to explore some newer avenues for non-rooted devices.
 Please shamelessly copy whatever idea you like into other tools. :-)

--- a/android_unpinner/__main__.py
+++ b/android_unpinner/__main__.py
@@ -159,13 +159,11 @@ def process_xapks(apk_files: list[Path]) -> list[Path]:
     """
     ret = []
     for apk in apk_files:
-        if isinstance(apk, Path) and apk.suffix.lower() == ".xapk":
-            if apks := find_apks_in_xapk(apk):
-                ret.extend(apks)
-            else:
-                ret.append(apk)
+        if apks := find_apks_in_xapk(apk):
+            ret.extend(apks)
         else:
             ret.append(apk)
+
     return ret
 
 

--- a/android_unpinner/__main__.py
+++ b/android_unpinner/__main__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import zipfile
 import asyncio
 import logging
 import subprocess
@@ -100,6 +102,71 @@ def install_apk(apk_files: list[Path]) -> None:
         adb(f"install-multiple --no-incremental {' '.join(str(x) for x in apk_files)}")
     else:
         adb(f"install --no-incremental {apk_files[0]}")
+
+
+def find_apks_in_xapk(xapk_path: Path, output_dir = None) -> list[Path] | None:
+    """
+    Extracts APK files from an XAPK file to a folder and returns their paths.
+    """
+
+    if not xapk_path.name.lower().endswith(".xapk"):
+        return None
+
+    if not os.path.exists(xapk_path):
+        return None
+    
+    logging.info(f"Processing XAPK: {os.path.basename(xapk_path)}")
+    
+    if output_dir is None:
+        base_name = os.path.basename(xapk_path)
+        dir_name = "XAPKs" + os.path.sep + os.path.splitext(base_name)[0].replace(" ", "_") + "_extracted"
+        extraction_dir = os.path.join(os.path.dirname(xapk_path), dir_name)
+    else:
+        extraction_dir = os.path.abspath(output_dir)
+
+    if os.path.exists(extraction_dir):
+        logging.warning(f"Directory '{extraction_dir}' already exists. New files will be merged/overwritten.")
+    else:
+        os.makedirs(extraction_dir)
+        logging.info(f"Created extraction directory: {extraction_dir}")
+
+    apk_files = []
+
+    try:        
+        with zipfile.ZipFile(xapk_path, 'r') as zip_ref:
+            zip_ref.extractall(extraction_dir)
+            logging.info("XAPK extraction complete.")
+
+        logging.info("Searching for APK files...")
+        for root, _, files in os.walk(extraction_dir):
+            for file_name in files:
+                if file_name.lower().endswith(".apk"):
+                    full_path = os.path.join(root, file_name)
+                    apk_files.append(Path(full_path))
+                    logging.info(f"Found APK: {full_path}")
+                    
+        return apk_files
+
+    except zipfile.BadZipFile:
+        logging.error(f"Error: '{xapk_path}' is not a valid ZIP file.")
+        return None
+    except Exception as e:
+        logging.error(f"An unexpected error occurred: {e}")
+        return None
+
+
+def process_xapks(apk_files: list[Path]) -> list[Path]:
+    """
+    Preprocess the list of APK files to handle any XAPK files.
+    """
+    apk_files = list(apk_files)
+    for apk in apk_files:
+        if isinstance(apk, Path) and apk.suffix.lower() == ".xapk":
+            apk_files.remove(apk)
+            found_apks = find_apks_in_xapk(apk)
+            if found_apks:
+                apk_files += found_apks
+    return apk_files
 
 
 def copy_files() -> None:
@@ -276,6 +343,7 @@ def all_cmd(apk_files: list[Path]) -> None:
 
     You may pass multiple files for the same package in case of split APKs.
     """
+    apk_files = process_xapks(apk_files)
     package_names = {build_tools.package_name(apk) for apk in apk_files}
     if len(package_names) > 1:
         raise RuntimeError(
@@ -306,6 +374,7 @@ def install_cmd(apk_files: list[Path]) -> None:
 
     You may pass multiple files for the same package in case of split APKs.
     """
+    apk_files = process_xapks(apk_files)
     install_apk(apk_files)
     logging.info("All done! 🎉")
 
@@ -321,6 +390,7 @@ def install_cmd(apk_files: list[Path]) -> None:
 )
 def patch_apks(apks: list[Path]) -> None:
     """Patch an APK file to be debuggable."""
+    apks = process_xapks(apks)
     patch_apk_files(apks)
     logging.info("All done! 🎉")
 

--- a/android_unpinner/__main__.py
+++ b/android_unpinner/__main__.py
@@ -118,7 +118,7 @@ def find_apks_in_xapk(xapk_path: Path, output_dir = None) -> list[Path] | None:
     logging.info(f"Processing XAPK: {os.path.basename(xapk_path)}")
     
     if output_dir is None:
-        extraction_dir = Path(os.path.join(xapk_path.parent, "XAPKs", f"{xapk_path.stem.replace(' ', '_')}_extracted")).resolve()
+        extraction_dir = xapk_path.parent / f"{xapk_path.stem}_extracted"
     else:
         extraction_dir = Path(output_dir).resolve()
 

--- a/android_unpinner/__main__.py
+++ b/android_unpinner/__main__.py
@@ -118,11 +118,9 @@ def find_apks_in_xapk(xapk_path: Path, output_dir = None) -> list[Path] | None:
     logging.info(f"Processing XAPK: {os.path.basename(xapk_path)}")
     
     if output_dir is None:
-        base_name = os.path.basename(xapk_path)
-        dir_name = "XAPKs" + os.path.sep + os.path.splitext(base_name)[0].replace(" ", "_") + "_extracted"
-        extraction_dir = os.path.join(os.path.dirname(xapk_path), dir_name)
+        extraction_dir = os.path.join(xapk_path.parent, "XAPKs", f"{xapk_path.stem.replace(' ', '_')}_extracted")
     else:
-        extraction_dir = os.path.abspath(output_dir)
+        extraction_dir = Path(output_dir).resolve()
 
     if os.path.exists(extraction_dir):
         logging.warning(f"Directory '{extraction_dir}' already exists. New files will be merged/overwritten.")
@@ -159,14 +157,14 @@ def process_xapks(apk_files: list[Path]) -> list[Path]:
     """
     Preprocess the list of APK files to handle any XAPK files.
     """
-    apk_files = list(apk_files)
+    ret = []
     for apk in apk_files:
         if isinstance(apk, Path) and apk.suffix.lower() == ".xapk":
-            apk_files.remove(apk)
-            found_apks = find_apks_in_xapk(apk)
-            if found_apks:
-                apk_files += found_apks
-    return apk_files
+            if apks := find_apks_in_xapk(apk):
+                ret.extend(apks)
+            else:
+                ret.append(apk)
+    return ret
 
 
 def copy_files() -> None:

--- a/android_unpinner/__main__.py
+++ b/android_unpinner/__main__.py
@@ -118,7 +118,7 @@ def find_apks_in_xapk(xapk_path: Path, output_dir = None) -> list[Path] | None:
     logging.info(f"Processing XAPK: {os.path.basename(xapk_path)}")
     
     if output_dir is None:
-        extraction_dir = Path(os.path.join(xapk_path.parent, "XAPKs", f"{xapk_path.stem.replace(' ', '_')}_extracted"))
+        extraction_dir = Path(os.path.join(xapk_path.parent, "XAPKs", f"{xapk_path.stem.replace(' ', '_')}_extracted")).resolve()
     else:
         extraction_dir = Path(output_dir).resolve()
 

--- a/android_unpinner/__main__.py
+++ b/android_unpinner/__main__.py
@@ -118,7 +118,7 @@ def find_apks_in_xapk(xapk_path: Path, output_dir = None) -> list[Path] | None:
     logging.info(f"Processing XAPK: {os.path.basename(xapk_path)}")
     
     if output_dir is None:
-        extraction_dir = os.path.join(xapk_path.parent, "XAPKs", f"{xapk_path.stem.replace(' ', '_')}_extracted")
+        extraction_dir = Path(os.path.join(xapk_path.parent, "XAPKs", f"{xapk_path.stem.replace(' ', '_')}_extracted"))
     else:
         extraction_dir = Path(output_dir).resolve()
 

--- a/android_unpinner/__main__.py
+++ b/android_unpinner/__main__.py
@@ -164,6 +164,8 @@ def process_xapks(apk_files: list[Path]) -> list[Path]:
                 ret.extend(apks)
             else:
                 ret.append(apk)
+        else:
+            ret.append(apk)
     return ret
 
 


### PR DESCRIPTION
Currently, if you wish to unpin an XAPK, you have to extract all APKs within and pass each one as an input.
Example command: `android-unpinner all ./config.arm64_v8a.apk ./config.en.apk ./actual-application.apk`

This is simple and works fine, but it is (to my knowledge) undocumented and not trivial. As seen in discussion posts [35](https://github.com/mitmproxy/android-unpinner/discussions/35) and [33](https://github.com/mitmproxy/android-unpinner/discussions/33), users are struggling with this (and none of the posts even come to a proper conclusion). It took me a while to figure this out myself, which is why I wrote this. One solution would be to better document this process, another would be to automate this process which I've done in this pull request.

This commit adds a new handler for input files ending in .xapk, where it extracts the APK files and replaces the .xapk input path with the list of extracted APKs. In other words it simply preprocesses the user input.

Tested and working on Windows 11. Would appreciate further testing on other OSes as the new code does a lot of file/path handling.